### PR TITLE
Dashboard & Analytics overview includes comments stats

### DIFF
--- a/cypress/fixtures/listOfArticles.json
+++ b/cypress/fixtures/listOfArticles.json
@@ -13,7 +13,8 @@
         "last_name": "Kramer"
       },
       "premium": true,
-      "published": false
+      "published": false,
+      "comments": 0
     },
     {
       "id": 6,
@@ -28,7 +29,8 @@
         "last_name": "Kramer"
       },
       "premium": true,
-      "published": true
+      "published": true,
+      "comments": 3
     },
     {
       "id": 5,
@@ -43,7 +45,8 @@
         "last_name": "Fake"
       },
       "premium": false,
-      "published": true
+      "published": true,
+      "comments": 2
     },
     {
       "id": 4,
@@ -58,7 +61,8 @@
         "last_name": "Kramer"
       },
       "premium": false,
-      "published": true
+      "published": true,
+      "comments": 5
     },
     {
       "id": 3,
@@ -73,7 +77,8 @@
         "last_name": "Fake"
       },
       "premium": true,
-      "published": false
+      "published": false,
+      "comments": 0
     },
     {
       "id": 2,
@@ -88,7 +93,8 @@
         "last_name": "Kramer"
       },
       "premium": false,
-      "published": true
+      "published": true,
+      "comments": 12
     },
     {
       "id": 1,
@@ -103,7 +109,8 @@
         "last_name": "Fake"
       },
       "premium": true,
-      "published": true
+      "published": true,
+      "comments": 3
     }
   ]
 }

--- a/cypress/fixtures/statisticsResponse.json
+++ b/cypress/fixtures/statisticsResponse.json
@@ -11,6 +11,9 @@
     "journalists": {
       "total": 4
     },
+    "comments": {
+      "total": 27
+    },
     "articles_timeline": [
       {
         "date": "2021-05-27",

--- a/cypress/integration/editor/editorCanSeeCompanyStatistics.feature.js
+++ b/cypress/integration/editor/editorCanSeeCompanyStatistics.feature.js
@@ -26,16 +26,20 @@ describe('Can get an overview of company statistics', () => {
         .eq(1)
         .find('[data-cy=amount]')
         .should('contain', 7);
-      cy.get('[data-cy=company-stats]')
+        cy.get('[data-cy=company-stats]')
         .eq(2)
         .find('[data-cy=amount]')
-        .should('contain', 4);
+        .should('contain', 27);
       cy.get('[data-cy=company-stats]')
         .eq(3)
         .find('[data-cy=amount]')
-        .should('contain', 10);
+        .should('contain', 4);
       cy.get('[data-cy=company-stats]')
         .eq(4)
+        .find('[data-cy=amount]')
+        .should('contain', 10);
+      cy.get('[data-cy=company-stats]')
+        .eq(5)
         .find('[data-cy=amount]')
         .should('contain', 1170);
     });

--- a/cypress/integration/journalist/userCanSeeTheirArticles.feature.js
+++ b/cypress/integration/journalist/userCanSeeTheirArticles.feature.js
@@ -34,6 +34,7 @@ describe('User can see their articles', () => {
           cy.get('[data-cy=premium]').should('contain', 'Premium');
           cy.get('[data-cy=author]').should('contain', 'Bob Kramer');
           cy.get('[data-cy=rating]').should('be.visible');
+          cy.get('[data-cy=comments]').should('contain', '0');
           cy.get('[data-cy=published]').should('contain', 'Unpublished');
         });
     });

--- a/src/components/ArticleTable.jsx
+++ b/src/components/ArticleTable.jsx
@@ -26,9 +26,7 @@ const ArticleTable = () => {
           ? `${article.author.first_name} ${article.author.last_name}`
           : 'Bob Kramer'}
       </Table.Cell>
-      <Table.Cell data-cy='premium'>
-        {article.premium ? 'Premium' : 'Free'}
-      </Table.Cell>
+      <Table.Cell data-cy='comments'>{article.comments}</Table.Cell>
       <Table.Cell>
         <Rating
           data-cy='rating'
@@ -38,6 +36,9 @@ const ArticleTable = () => {
           maxRating={5}
           disabled
         />
+      </Table.Cell>
+      <Table.Cell data-cy='premium'>
+        {article.premium ? 'Premium' : 'Free'}
       </Table.Cell>
       <Table.Cell data-cy='published'>
         {article.published ? 'Published' : 'Unpublished'}
@@ -57,15 +58,16 @@ const ArticleTable = () => {
   ));
 
   return (
-    <Table celled padded inverted style={{ overflowY: 'scroll' }}>
+    <Table stackable celled padded inverted style={{ overflowY: 'scroll' }}>
       <Table.Header>
         <Table.Row textAlign='center'>
           <Table.HeaderCell singleLine>Title</Table.HeaderCell>
-          <Table.HeaderCell>Categories</Table.HeaderCell>
+          <Table.HeaderCell>Category</Table.HeaderCell>
           <Table.HeaderCell>Updated On</Table.HeaderCell>
           <Table.HeaderCell>Author</Table.HeaderCell>
-          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell>Comments</Table.HeaderCell>
           <Table.HeaderCell>Rating</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
           <Table.HeaderCell>Published</Table.HeaderCell>
           <Table.HeaderCell>Action</Table.HeaderCell>
         </Table.Row>

--- a/src/components/SideMenu.jsx
+++ b/src/components/SideMenu.jsx
@@ -36,17 +36,18 @@ const SideMenu = () => {
         to='/dashboard'>
         Dashboard
       </Menu.Item>
-
-      <Menu.Item
-        name='create-article'
-        data-cy='create-article-btn'
-        active={activeItem === 'create-article'}
-        onClick={handleItemClick}
-        as={Link}
-        to='/create'>
-        Write new article
-        <Icon name='plus' style={{color: '#fdfd96'}}></Icon>
-      </Menu.Item>
+      {role === 'journalist' && (
+        <Menu.Item
+          name='create-article'
+          data-cy='create-article-btn'
+          active={activeItem === 'create-article'}
+          onClick={handleItemClick}
+          as={Link}
+          to='/create'>
+          Write new article
+          <Icon name='plus' style={{ color: '#fdfd96' }}></Icon>
+        </Menu.Item>
+      )}
 
       {role === 'editor' && (
         <Menu.Item
@@ -57,7 +58,7 @@ const SideMenu = () => {
           onClick={handleItemClick}
           as={Link}
           to='/overview'>
-          Overview
+          Analytics Overview
         </Menu.Item>
       )}
     </Menu>

--- a/src/components/editor/EditorOverview.jsx
+++ b/src/components/editor/EditorOverview.jsx
@@ -36,7 +36,7 @@ const EditorOverview = () => {
           />
           <StatCard
             data={statistics.comments}
-            title='Total comments'
+            title='Comments'
             icon='comments'
             color='#fdfd96'
           />
@@ -59,7 +59,7 @@ const EditorOverview = () => {
 
               <StatCard
                 data={statistics.total_income}
-                title='Total Monthly Income'
+                title='Monthly Income (SEK)'
                 icon='money bill alternate'
                 color='#21d3a4'
               />

--- a/src/components/editor/EditorOverview.jsx
+++ b/src/components/editor/EditorOverview.jsx
@@ -26,21 +26,28 @@ const EditorOverview = () => {
             data={statistics.articles}
             title='Articles'
             icon='newspaper outline'
-            color='violet'
+            color='#fdfd96'
           />
           <StatCard
             data={statistics.backyard_articles}
             title='Backyard Articles'
             icon='newspaper'
-            color='violet'
+            color='#fdfd96'
           />
+          <StatCard
+            data={statistics.comments}
+            title='Total comments'
+            icon='comments'
+            color='#fdfd96'
+          />
+        </div>
+        <div style={styles.cardContainer}>
           <StatCard
             data={statistics.journalists}
             title='Journalists'
             icon='user'
-            color='#fdfd96'
+            color='#21d3a4'
           />
-
           {!error && (
             <>
               <StatCard
@@ -83,7 +90,7 @@ const styles = {
     flexWrap: 'wrap',
     flex: 1,
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'space-evenly',
   },
 
   graphContainer: {


### PR DESCRIPTION
[**PT-Story:**  ](https://www.pivotaltracker.com/story/show/178269711)
### User Story 
``` 
As an editor
In order to gain insights into the new Comments entity
I want to see a total amount of comments as well as an amount for each article
``` 
## Changes proposed in this pull request: 
* Adds comments to fixtures
* Adds amount of comments for each article in Article Table
* Adds total amount of comments in Analytics overview

## Screenshots (Client)
![image](https://user-images.githubusercontent.com/75306727/119974006-78678200-bfb4-11eb-9e43-f4ceb6d92329.png)