### PR TITLE
New article status  buttons 

### DIFF
--- a/cypress/fixtures/listOfArticles.json
+++ b/cypress/fixtures/listOfArticles.json
@@ -13,7 +13,7 @@
         "last_name": "Kramer"
       },
       "premium": true,
-      "published": false,
+      "status": "Draft",
       "comments": 0
     },
     {
@@ -29,7 +29,7 @@
         "last_name": "Kramer"
       },
       "premium": true,
-      "published": true,
+      "status": "Published",
       "comments": 3
     },
     {
@@ -44,8 +44,8 @@
         "first_name": "Mr.",
         "last_name": "Fake"
       },
-      "premium": false,
-      "published": true,
+      "premium": true,
+      "status": "Archived",
       "comments": 2
     },
     {
@@ -60,8 +60,8 @@
         "first_name": "Bob",
         "last_name": "Kramer"
       },
-      "premium": false,
-      "published": true,
+      "premium": true,
+      "status": "Published",
       "comments": 5
     },
     {
@@ -77,7 +77,7 @@
         "last_name": "Fake"
       },
       "premium": true,
-      "published": false,
+      "status": "Draft",
       "comments": 0
     },
     {
@@ -92,8 +92,8 @@
         "first_name": "Bob",
         "last_name": "Kramer"
       },
-      "premium": false,
-      "published": true,
+      "premium": true,
+      "status": "Published",
       "comments": 12
     },
     {
@@ -109,7 +109,7 @@
         "last_name": "Fake"
       },
       "premium": true,
-      "published": true,
+      "status": "Published",
       "comments": 3
     }
   ]

--- a/cypress/fixtures/listOfBackyardArticles.json
+++ b/cypress/fixtures/listOfBackyardArticles.json
@@ -6,7 +6,8 @@
       "date": "2021-05-19, 15:10",
       "written_by": "Bob Kramer",
       "theme": "My cat is spying on me",
-      "location": "Denmark"
+      "location": "Denmark",
+      "status": "Published"
     },
     {
       "id": 2,
@@ -14,7 +15,8 @@
       "date": "2021-05-19, 15:10",
       "written_by": "Mrs Kramer",
       "theme": "My cat is an Alien",
-      "location": "Sweden"
+      "location": "Sweden",
+      "status": "Published"
     },
     {
       "id": 3,
@@ -22,7 +24,8 @@
       "date": "2021-05-19, 15:10",
       "written_by": "Bob Kramer",
       "theme": "My cat ate my dog??",
-      "location": "Denmark"
+      "location": "Denmark",
+      "status": "Published"
     },
     {
       "id": 4,
@@ -30,7 +33,8 @@
       "date": "2021-05-19, 15:10",
       "written_by": "Bob Kramer",
       "theme": "My cat is talking to me",
-      "location": "Sweden"
+      "location": "Sweden",
+      "status": "Published"
     },
     {
       "id": 5,
@@ -38,7 +42,8 @@
       "date": "2021-05-19, 15:10",
       "written_by": "Finn Kramer",
       "theme": "Is my cat a dog?",
-      "location": "Denmark"
+      "location": "Denmark",
+      "status": "Published"
     },
     {
       "id": 6,
@@ -46,7 +51,8 @@
       "date": "2021-05-19, 15:10",
       "written_by": "Bob Kramer",
       "theme": "Do I even have a cat?",
-      "location": "Denmark"
+      "location": "Denmark",
+      "status": "Published"
     }
   ]
 }

--- a/cypress/fixtures/listOfBackyardArticles.json
+++ b/cypress/fixtures/listOfBackyardArticles.json
@@ -16,7 +16,7 @@
       "written_by": "Mrs Kramer",
       "theme": "My cat is an Alien",
       "location": "Sweden",
-      "status": "Published"
+      "status": "Archived"
     },
     {
       "id": 3,

--- a/cypress/integration/editor/editorCanArchiveArticles.feature.js
+++ b/cypress/integration/editor/editorCanArchiveArticles.feature.js
@@ -1,4 +1,4 @@
-describe('Publishing articles', () => {
+describe('Archiving articles', () => {
   beforeEach(() => {
     cy.intercept('GET', 'https://fakest-newzz.herokuapp.com/api/articles', {
       fixture: 'listOfArticles.json',
@@ -8,7 +8,7 @@ describe('Publishing articles', () => {
   describe('Successfully as an editor', () => {
     beforeEach(() => {
       cy.intercept('PUT', 'https://fakest-newzz.herokuapp.com/api/articles/7', {
-        message: 'The article has been successfully published',
+        message: 'The article has been successfully archived',
       });
       cy.visit('/');
       cy.window()
@@ -21,16 +21,16 @@ describe('Publishing articles', () => {
 
     it('is expected to display a success message', () => {
       cy.get('[data-cy=action-btn]').first().click();
-      cy.get('button').contains('Publish').click();
+      cy.get('button').contains('Archive').click();
       cy.get('button').contains('Confirm').click();
       cy.get('[data-cy=popup-message]').should(
         'contain',
-        'The article has been successfully published'
+        'The article has been successfully archived'
       );
     });
   });
 
-  describe('Unsuccessfully when article is already published', () => {
+  describe('Unsuccessfully when article is already archived', () => {
     beforeEach(() => {
       cy.visit('/');
       cy.window()
@@ -41,10 +41,10 @@ describe('Publishing articles', () => {
         });
     });
 
-    it('is expected to show an archive button instead', () => {
-      cy.get('[data-cy=action-btn]').eq(1).click();
-      cy.get('button').contains('Publish').should('not.exist');
-      cy.get('button').contains('Archive').should('be.visible');
+    it('is expected to show a publish button instead', () => {
+      cy.get('[data-cy=action-btn]').eq(2).click();
+      cy.get('button').contains('Archive').should('not.exist');
+      cy.get('button').contains('Publish').should('be.visible');
     });
   });
 

--- a/cypress/integration/editor/editorCanArchiveArticles.feature.js
+++ b/cypress/integration/editor/editorCanArchiveArticles.feature.js
@@ -7,7 +7,7 @@ describe('Archiving articles', () => {
 
   describe('Successfully as an editor', () => {
     beforeEach(() => {
-      cy.intercept('PUT', 'https://fakest-newzz.herokuapp.com/api/articles/7', {
+      cy.intercept('PUT', 'https://fakest-newzz.herokuapp.com/api/articles/**', {
         message: 'The article has been successfully archived',
       });
       cy.visit('/');
@@ -20,7 +20,7 @@ describe('Archiving articles', () => {
     });
 
     it('is expected to display a success message', () => {
-      cy.get('[data-cy=action-btn]').first().click();
+      cy.get('[data-cy=action-btn]').eq(1).click();
       cy.get('button').contains('Archive').click();
       cy.get('button').contains('Confirm').click();
       cy.get('[data-cy=popup-message]').should(

--- a/cypress/integration/editor/editorCanModerateBackyardArticles.feature.js
+++ b/cypress/integration/editor/editorCanModerateBackyardArticles.feature.js
@@ -20,7 +20,7 @@ describe('Editor can moderate backyard articles', () => {
     beforeEach(() => {
       cy.intercept(
         'PUT',
-        'https://fakest-newzz.herokuapp.com/api/bakyards/**',
+        'https://fakest-newzz.herokuapp.com/api/backyards/**',
         {
           message: 'The backyard article has been successfully archived',
         }
@@ -42,7 +42,7 @@ describe('Editor can moderate backyard articles', () => {
     beforeEach(() => {
       cy.intercept(
         'PUT',
-        'https://fakest-newzz.herokuapp.com/api/bakyards/**',
+        'https://fakest-newzz.herokuapp.com/api/backyards/**',
         {
           message: 'The backyard article has been successfully published',
         }

--- a/cypress/integration/editor/editorCanModerateBackyardArticles.feature.js
+++ b/cypress/integration/editor/editorCanModerateBackyardArticles.feature.js
@@ -1,0 +1,62 @@
+describe('Editor can moderate backyard articles', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'https://fakest-newzz.herokuapp.com/api/articles', {
+      fixture: 'listOfArticles.json',
+    });
+    cy.intercept('GET', 'https://fakest-newzz.herokuapp.com/api/backyards', {
+      fixture: 'listOfBackyardArticles.json',
+    });
+    cy.visit('/');
+    cy.window()
+      .its('store')
+      .invoke('dispatch', {
+        type: 'LOG_IN',
+        payload: { fullName: 'Mr. Editor', role: 'editor' },
+      });
+    cy.get('a').contains('Backyard Articles').click();
+  });
+
+  describe('by successfully archiving the article', () => {
+    beforeEach(() => {
+      cy.intercept(
+        'PUT',
+        'https://fakest-newzz.herokuapp.com/api/bakyards/**',
+        {
+          message: 'The backyard article has been successfully archived',
+        }
+      );
+    });
+
+    it('is expected to display a success message', () => {
+      cy.get('[data-cy=action-btn]').first().click();
+      cy.get('button').contains('Archive').click();
+      cy.get('button').contains('Confirm').click();
+      cy.get('[data-cy=popup-message]').should(
+        'contain',
+        'The backyard article has been successfully archived'
+      );
+    });
+  });
+
+  describe('by successfully publishing the article', () => {
+    beforeEach(() => {
+      cy.intercept(
+        'PUT',
+        'https://fakest-newzz.herokuapp.com/api/bakyards/**',
+        {
+          message: 'The backyard article has been successfully published',
+        }
+      );
+    });
+
+    it('is expected to display a success message', () => {
+      cy.get('[data-cy=action-btn]').eq(1).click();
+      cy.get('button').contains('Publish').click();
+      cy.get('button').contains('Confirm').click();
+      cy.get('[data-cy=popup-message]').should(
+        'contain',
+        'The backyard article has been successfully published'
+      );
+    });
+  });
+});

--- a/cypress/integration/editor/editorCanPublishArticles.feature.js
+++ b/cypress/integration/editor/editorCanPublishArticles.feature.js
@@ -7,7 +7,7 @@ describe('Publishing articles', () => {
 
   describe('Successfully as an editor', () => {
     beforeEach(() => {
-      cy.intercept('PUT', 'https://fakest-newzz.herokuapp.com/api/articles/7', {
+      cy.intercept('PUT', 'https://fakest-newzz.herokuapp.com/api/articles/**', {
         message: 'The article has been successfully published',
       });
       cy.visit('/');

--- a/cypress/integration/editor/editorCanSeeBackyardDashboard.feature.js
+++ b/cypress/integration/editor/editorCanSeeBackyardDashboard.feature.js
@@ -44,8 +44,9 @@ describe('Backyard article dashboard can display articles', () => {
     });
 
     it('is expected to be able to see content of each article', () => {
-      cy.get('[data-cy=view-btn]').first().click();
-      cy.get('[data-cy=backyard-preview]').within(() => {
+      cy.get('[data-cy=action-btn]').first().click();
+      cy.get('[data-cy=view-btn]').click();
+      cy.get('[data-cy=article-preview]').within(() => {
         cy.get('[data-cy=title]').should('contain', 'Something awesome');
         cy.get('[data-cy=written_by]').should(
           'contain',

--- a/cypress/integration/editor/editorCanSeeBackyardDashboard.feature.js
+++ b/cypress/integration/editor/editorCanSeeBackyardDashboard.feature.js
@@ -39,6 +39,7 @@ describe('Backyard article dashboard can display articles', () => {
           cy.get('[data-cy=written-by]').should('contain', 'Bob Kramer');
           cy.get('[data-cy=date]').should('contain', '2021-05-19, 15:10');
           cy.get('[data-cy=country]').should('contain', 'Denmark');
+          cy.get('[data-cy=status]').should('contain', 'Published');
         });
     });
 

--- a/cypress/integration/journalist/userCanSeeTheirArticles.feature.js
+++ b/cypress/integration/journalist/userCanSeeTheirArticles.feature.js
@@ -35,7 +35,7 @@ describe('User can see their articles', () => {
           cy.get('[data-cy=author]').should('contain', 'Bob Kramer');
           cy.get('[data-cy=rating]').should('be.visible');
           cy.get('[data-cy=comments]').should('contain', '0');
-          cy.get('[data-cy=published]').should('contain', 'Unpublished');
+          cy.get('[data-cy=status]').should('contain', 'Draft');
         });
     });
 

--- a/src/components/ArticleTable.jsx
+++ b/src/components/ArticleTable.jsx
@@ -22,9 +22,8 @@ const ArticleTable = () => {
       </Table.Cell>
       <Table.Cell data-cy='date'>{article.date}</Table.Cell>
       <Table.Cell data-cy='author'>
-        {article.author
-          ? `${article.author.first_name} ${article.author.last_name}`
-          : 'Bob Kramer'}
+        {article.author &&
+          `${article.author.first_name} ${article.author.last_name}`}
       </Table.Cell>
       <Table.Cell data-cy='comments'>{article.comments}</Table.Cell>
       <Table.Cell>

--- a/src/components/ArticleTable.jsx
+++ b/src/components/ArticleTable.jsx
@@ -55,7 +55,7 @@ const ArticleTable = () => {
   ));
 
   return (
-    <Table stackable celled padded inverted style={{ overflowY: 'scroll' }}>
+    <Table celled padded inverted stackable={true}>
       <Table.Header>
         <Table.Row textAlign='center'>
           <Table.HeaderCell singleLine>Title</Table.HeaderCell>

--- a/src/components/ArticleTable.jsx
+++ b/src/components/ArticleTable.jsx
@@ -40,9 +40,7 @@ const ArticleTable = () => {
       <Table.Cell data-cy='premium'>
         {article.premium ? 'Premium' : 'Free'}
       </Table.Cell>
-      <Table.Cell data-cy='published'>
-        {article.published ? 'Published' : 'Unpublished'}
-      </Table.Cell>
+      <Table.Cell data-cy='status'>{article.status}</Table.Cell>
       <Table.Cell>
         {role === 'editor' ? (
           <EditorActionButton article={article} />
@@ -67,8 +65,8 @@ const ArticleTable = () => {
           <Table.HeaderCell>Author</Table.HeaderCell>
           <Table.HeaderCell>Comments</Table.HeaderCell>
           <Table.HeaderCell>Rating</Table.HeaderCell>
+          <Table.HeaderCell>Access</Table.HeaderCell>
           <Table.HeaderCell>Status</Table.HeaderCell>
-          <Table.HeaderCell>Published</Table.HeaderCell>
           <Table.HeaderCell>Action</Table.HeaderCell>
         </Table.Row>
       </Table.Header>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -88,14 +88,4 @@ const styles = {
     backgroundColor: '#202325',
     width: '100%',
   },
-  formContainer: {
-    width: '45%',
-    marginLeft: '5%',
-    padding: 10,
-  },
-  createButton: {
-    position: 'absolute',
-    top: 105,
-    left: 300,
-  },
 };

--- a/src/components/StatsGraphs.jsx
+++ b/src/components/StatsGraphs.jsx
@@ -20,10 +20,16 @@ const StatsGraphs = ({ data }) => {
   const { error } = useSelector((state) => state);
 
   return (
-    <div style={styles.containerBigScreen}>
+    <div style={styles.container}>
       {data && (
         <>
-          <div data-cy='articles-graph' style={{ height: 400, width: isSmallScreen ? '100%' : '60%', marginBottom: 100}}>
+          <div
+            data-cy='articles-graph'
+            style={{
+              height: 400,
+              width: isSmallScreen ? '100%' : '60%',
+              marginBottom: 100,
+            }}>
             <h1 style={{ color: 'white', textAlign: 'center' }}>
               Articles created timeline
             </h1>
@@ -110,16 +116,10 @@ const StatsGraphs = ({ data }) => {
 export default StatsGraphs;
 
 const styles = {
-  containerBigScreen: {
+  container: {
     display: 'flex',
-    flex: 1,
+    width: '100%',
     justifyContent: 'space-between',
-    flexWrap: 'wrap'
-  },
-  containerSmallScreen: {
-    display: 'flex',
-    flex: 1,
-    flexDirection: 'column',
-    justifyContent: 'center',
+    flexWrap: 'wrap',
   },
 };

--- a/src/components/editor/BackyardArticleTable.jsx
+++ b/src/components/editor/BackyardArticleTable.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Table } from 'semantic-ui-react';
 import { useSelector } from 'react-redux';
-import BackyardModal from './BackyardModal';
 import { Redirect } from 'react-router';
+import EditorActionButton from './EditorActionButton';
 
 const BackyardArticleTable = () => {
   const { backyardArticles, role } = useSelector((state) => state);
@@ -25,11 +25,9 @@ const BackyardArticleTable = () => {
       <Table.Cell data-cy='date'>{backyardArticle.date}</Table.Cell>
       <Table.Cell data-cy='written-by'>{backyardArticle.written_by}</Table.Cell>
       <Table.Cell data-cy='country'>{backyardArticle.location}</Table.Cell>
-      <Table.Cell data-cy='status'>
-        {backyardArticle.status}
-      </Table.Cell>
+      <Table.Cell data-cy='status'>{backyardArticle.status}</Table.Cell>
       <Table.Cell>
-        <BackyardModal id={backyardArticle.id} />
+        <EditorActionButton article={backyardArticle} />
       </Table.Cell>
     </Table.Row>
   ));

--- a/src/components/editor/BackyardArticleTable.jsx
+++ b/src/components/editor/BackyardArticleTable.jsx
@@ -25,6 +25,9 @@ const BackyardArticleTable = () => {
       <Table.Cell data-cy='date'>{backyardArticle.date}</Table.Cell>
       <Table.Cell data-cy='written-by'>{backyardArticle.written_by}</Table.Cell>
       <Table.Cell data-cy='country'>{backyardArticle.location}</Table.Cell>
+      <Table.Cell data-cy='status'>
+        {article.status}
+      </Table.Cell>
       <Table.Cell>
         <BackyardModal id={backyardArticle.id} />
       </Table.Cell>
@@ -42,6 +45,7 @@ const BackyardArticleTable = () => {
             <Table.HeaderCell>Created On</Table.HeaderCell>
             <Table.HeaderCell>Written by</Table.HeaderCell>
             <Table.HeaderCell>Country</Table.HeaderCell>
+            <Table.HeaderCell>Status</Table.HeaderCell>
             <Table.HeaderCell>Action</Table.HeaderCell>
           </Table.Row>
         </Table.Header>

--- a/src/components/editor/BackyardArticleTable.jsx
+++ b/src/components/editor/BackyardArticleTable.jsx
@@ -26,7 +26,7 @@ const BackyardArticleTable = () => {
       <Table.Cell data-cy='written-by'>{backyardArticle.written_by}</Table.Cell>
       <Table.Cell data-cy='country'>{backyardArticle.location}</Table.Cell>
       <Table.Cell data-cy='status'>
-        {article.status}
+        {backyardArticle.status}
       </Table.Cell>
       <Table.Cell>
         <BackyardModal id={backyardArticle.id} />

--- a/src/components/editor/BackyardArticleTable.jsx
+++ b/src/components/editor/BackyardArticleTable.jsx
@@ -27,7 +27,7 @@ const BackyardArticleTable = () => {
       <Table.Cell data-cy='country'>{backyardArticle.location}</Table.Cell>
       <Table.Cell data-cy='status'>{backyardArticle.status}</Table.Cell>
       <Table.Cell>
-        <EditorActionButton article={backyardArticle} />
+        <EditorActionButton article={backyardArticle} isBackyard={true}/>
       </Table.Cell>
     </Table.Row>
   ));

--- a/src/components/editor/EditorActionButton.jsx
+++ b/src/components/editor/EditorActionButton.jsx
@@ -6,6 +6,13 @@ import Articles from '../../modules/Articles';
 const EditorActionButton = ({ article }) => {
   const [confirming, setConfirming] = useState(false);
 
+  // change attribute to status fixture CHECK
+  // change published attribute to backyard fixture CHECK
+  // change display columns CHECK
+  // Publish param = status: published
+  // Archive = status: archive
+  // Unpublish to backyard articles - published: true/false
+
   return (
     <Popup
       trigger={<Button data-cy='action-btn'>Actions</Button>}

--- a/src/components/editor/EditorActionButton.jsx
+++ b/src/components/editor/EditorActionButton.jsx
@@ -3,8 +3,9 @@ import { Popup, Button } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import Articles from '../../modules/Articles';
 import PreviewModal from './PreviewModal';
+import BackyardArticles from '../../modules/BackyardArticles';
 
-const EditorActionButton = ({ article }) => {
+const EditorActionButton = ({ article, isBackyard }) => {
   const [confirming, setConfirming] = useState(false);
 
   // change attribute to status fixture CHECK
@@ -29,7 +30,11 @@ const EditorActionButton = ({ article }) => {
           <>
             <Button
               style={{ marginBottom: 10 }}
-              onClick={() => Articles.setStatus(article.id, article.status)}>
+              onClick={() =>
+                isBackyard
+                  ? BackyardArticles.setStatus(article.id, article.status)
+                  : Articles.setStatus(article.id, article.status)
+              }>
               Confirm
             </Button>
             <Button onClick={() => setConfirming(false)}>Cancel</Button>
@@ -41,7 +46,7 @@ const EditorActionButton = ({ article }) => {
               onClick={() => setConfirming(true)}>
               {article.status === 'Published' ? 'Archive' : 'Publish'}
             </Button>
-            {article.author && (
+            {!isBackyard && (
               <Link
                 style={{ width: '100%', marginBottom: 10 }}
                 data-cy='edit-article-btn'
@@ -49,7 +54,7 @@ const EditorActionButton = ({ article }) => {
                 <Button style={{ width: '100%' }}>Edit</Button>
               </Link>
             )}
-            <PreviewModal id={article.id} isBackyard={article.written_by} />
+            <PreviewModal id={article.id} isBackyard={isBackyard} />
           </>
         )}
       </div>

--- a/src/components/editor/EditorActionButton.jsx
+++ b/src/components/editor/EditorActionButton.jsx
@@ -28,18 +28,18 @@ const EditorActionButton = ({ article }) => {
           <>
             <Button
               style={{ marginBottom: 10 }}
-              onClick={() => Articles.publish(article.id)}>
+              onClick={() => Articles.setStatus(article.id, article.status)}>
               Confirm
             </Button>
             <Button onClick={() => setConfirming(false)}>Cancel</Button>
           </>
         ) : (
           <>
-            <Button
+            <Button 
               style={{ marginBottom: 10, width: '100%' }}
               disabled={article.published}
               onClick={() => setConfirming(true)}>
-              Publish
+              {article.status === 'Published' ? 'Archive' : 'Publish'}
             </Button>
             <Link
               style={{ width: '100%' }}

--- a/src/components/editor/EditorActionButton.jsx
+++ b/src/components/editor/EditorActionButton.jsx
@@ -9,9 +9,9 @@ const EditorActionButton = ({ article }) => {
   // change attribute to status fixture CHECK
   // change published attribute to backyard fixture CHECK
   // change display columns CHECK
-  // Publish param = status: published
-  // Archive = status: archive
-  // Unpublish to backyard articles - published: true/false
+  // Publish param = status: published check
+  // Archive = status: archive CGECK
+  // Unpublish to backyard articles - status
 
   return (
     <Popup

--- a/src/components/editor/EditorActionButton.jsx
+++ b/src/components/editor/EditorActionButton.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Popup, Button } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import Articles from '../../modules/Articles';
+import PreviewModal from './PreviewModal';
 
 const EditorActionButton = ({ article }) => {
   const [confirming, setConfirming] = useState(false);
@@ -35,18 +36,20 @@ const EditorActionButton = ({ article }) => {
           </>
         ) : (
           <>
-            <Button 
+            <Button
               style={{ marginBottom: 10, width: '100%' }}
-              disabled={article.published}
               onClick={() => setConfirming(true)}>
               {article.status === 'Published' ? 'Archive' : 'Publish'}
             </Button>
-            <Link
-              style={{ width: '100%' }}
-              data-cy='edit-article-btn'
-              to={{ pathname: '/edit', state: { id: article.id } }}>
-              <Button style={{ width: '100%' }}>Edit</Button>
-            </Link>
+            {article.author && (
+              <Link
+                style={{ width: '100%', marginBottom: 10 }}
+                data-cy='edit-article-btn'
+                to={{ pathname: '/edit', state: { id: article.id } }}>
+                <Button style={{ width: '100%' }}>Edit</Button>
+              </Link>
+            )}
+            <PreviewModal id={article.id} isBackyard={article.written_by} />
           </>
         )}
       </div>

--- a/src/components/editor/PreviewModal.jsx
+++ b/src/components/editor/PreviewModal.jsx
@@ -40,7 +40,7 @@ const PreviewModal = ({ id, isBackyard }) => {
           `${article.author.first_name} ${article.author.last_name}`}
       </p>
       <p data-cy='category'>
-        <b>Category </b>
+        <b>Category: </b>
         {article.category}
       </p>
     </>
@@ -48,9 +48,8 @@ const PreviewModal = ({ id, isBackyard }) => {
 
   return (
     <Modal
-      as={Segment}
-      inverted
       open={open}
+      style={{ height: '80%', top: '10%' }}
       onClose={() => setOpen(false)}
       onOpen={() => setOpen(true)}
       trigger={
@@ -69,15 +68,26 @@ const PreviewModal = ({ id, isBackyard }) => {
           </p>
         </div>
         <Divider style={{ width: '70%', margin: '15px auto' }} />
-        <Modal.Content scrolling>
+        <Modal.Content>
           <Modal.Description>
-          {!isBackyard && (
-            <>
-            <img alt="title" src={article.image} style={{ width: '100%', margin: '15px auto' }}/>
-            <p style={{ fontSize: 20, margin: '18px auto',fontFamily:'garamond,serif' }}>{article.teaser}</p>
-            <Divider style={{ fontSize: 20, margin: '15px auto'}} />
-            </>
-          ) }
+            {!isBackyard && (
+              <>
+                <img
+                  alt='title'
+                  src={article.image}
+                  style={{ width: '100%', margin: '15px auto' }}
+                />
+                <p
+                  style={{
+                    fontSize: 20,
+                    margin: '18px auto',
+                    fontFamily: 'garamond,serif',
+                  }}>
+                  {article.teaser}
+                </p>
+                <Divider style={{ fontSize: 20, margin: '15px auto' }} />
+              </>
+            )}
             <p data-cy='content-body' style={styles.body}>
               {article.body}
             </p>
@@ -93,7 +103,9 @@ export default PreviewModal;
 const styles = {
   container: {
     padding: 50,
-    height: '30%',
+    zIndex: 50,
+    height: '100%',
+    overflowY: 'scroll',
   },
   info: {
     display: 'flex',

--- a/src/components/editor/PreviewModal.jsx
+++ b/src/components/editor/PreviewModal.jsx
@@ -2,15 +2,49 @@ import React, { useState } from 'react';
 import { Button, Modal, Segment, Divider } from 'semantic-ui-react';
 
 import BackyardArticles from '../../modules/BackyardArticles';
+import Articles from '../../modules/Articles';
 
-const BackyardModal = ({ id }) => {
+const PreviewModal = ({ id, isBackyard }) => {
   const [open, setOpen] = useState(false);
-  const [backyardArticle, setBackyardArticle] = useState({});
+  const [article, setArticle] = useState({});
 
-  const getBackyardArticle = async () => {
-    let response = await BackyardArticles.show(id);
-    setBackyardArticle(response);
+  const getArticle = async () => {
+    let response;
+    if (isBackyard) {
+      response = await BackyardArticles.show(id);
+    } else {
+      response = await Articles.show(id);
+    }
+    setArticle(response);
   };
+
+  const articleInfo = isBackyard ? (
+    <>
+      <p data-cy='written_by'>
+        <b>Written by: </b>
+        {article.written_by}
+      </p>
+      <p data-cy='theme'>
+        <b>Theme: </b>
+        {article.theme}
+      </p>
+      <p data-cy='country'>
+        <b>From:</b> {article.location}
+      </p>
+    </>
+  ) : (
+    <>
+      <p data-cy='author'>
+        <b>Written by: </b>
+        {article.author &&
+          `${article.author.first_name} ${article.author.last_name}`}
+      </p>
+      <p data-cy='category'>
+        <b>Category </b>
+        {article.category}
+      </p>
+    </>
+  );
 
   return (
     <Modal
@@ -20,35 +54,25 @@ const BackyardModal = ({ id }) => {
       onClose={() => setOpen(false)}
       onOpen={() => setOpen(true)}
       trigger={
-        <Button onClick={() => getBackyardArticle()} data-cy='view-btn'>
+        <Button onClick={() => getArticle()} data-cy='view-btn'>
           Preview
         </Button>
       }>
-      <Segment style={styles.container} inverted data-cy='backyard-preview'>
+      <Segment style={styles.container} inverted data-cy='article-preview'>
         <Modal.Header data-cy='title' style={styles.title}>
-          {backyardArticle.title}
+          {article.title}
         </Modal.Header>
         <div style={styles.info}>
-          <p data-cy='written_by'>
-            <b>Written by: </b>
-            {backyardArticle.written_by}
-          </p>
-          <p data-cy='theme'>
-            <b>Theme: </b>
-            {backyardArticle.theme}
-          </p>
-          <p data-cy='country'>
-            <b>From:</b> {backyardArticle.location}
-          </p>
+          {articleInfo}
           <p data-cy='date'>
-            <b>Date:</b> {backyardArticle.date}
+            <b>Date:</b> {article.date}
           </p>
         </div>
         <Divider style={{ width: '70%', margin: '15px auto' }} />
         <Modal.Content scrolling>
           <Modal.Description>
             <p data-cy='content-body' style={styles.body}>
-              {backyardArticle.body}
+              {article.body}
             </p>
           </Modal.Description>
         </Modal.Content>
@@ -57,7 +81,7 @@ const BackyardModal = ({ id }) => {
   );
 };
 
-export default BackyardModal;
+export default PreviewModal;
 
 const styles = {
   container: {

--- a/src/components/editor/PreviewModal.jsx
+++ b/src/components/editor/PreviewModal.jsx
@@ -71,6 +71,13 @@ const PreviewModal = ({ id, isBackyard }) => {
         <Divider style={{ width: '70%', margin: '15px auto' }} />
         <Modal.Content scrolling>
           <Modal.Description>
+          {!isBackyard && (
+            <>
+            <img alt="title" src={article.image} style={{ width: '100%', margin: '15px auto' }}/>
+            <p style={{ fontSize: 20, margin: '18px auto',fontFamily:'garamond,serif' }}>{article.teaser}</p>
+            <Divider style={{ fontSize: 20, margin: '15px auto'}} />
+            </>
+          ) }
             <p data-cy='content-body' style={styles.body}>
               {article.body}
             </p>

--- a/src/modules/Articles.js
+++ b/src/modules/Articles.js
@@ -62,7 +62,6 @@ const Articles = {
 
   async setStatus(id, status) {
     let params = { status: status === 'Published' ? 'archived': 'published'};
-    debugger
     try {
       let response = await axios.put(`/articles/${id}`, params, {
         headers: getFromLocalStorage(),

--- a/src/modules/Articles.js
+++ b/src/modules/Articles.js
@@ -60,8 +60,9 @@ const Articles = {
     }
   },
 
-  async publish(id) {
-    let params = { published: true };
+  async setStatus(id, status) {
+    let params = { status: status === 'Published' ? 'archived': 'published'};
+    debugger
     try {
       let response = await axios.put(`/articles/${id}`, params, {
         headers: getFromLocalStorage(),

--- a/src/modules/BackyardArticles.js
+++ b/src/modules/BackyardArticles.js
@@ -28,6 +28,23 @@ const BackyardArticles = {
       errorHandler(error);
     }
   },
+
+  async setStatus(id, status) {
+    let params = { status: status === 'Published' ? 'archived': 'published'};
+    debugger
+    try {
+      let response = await axios.put(`/backyards/${id}`, params, {
+        headers: getFromLocalStorage(),
+      });
+      BackyardArticles.index();
+      store.dispatch({
+        type: 'SUCCESS_MESSAGE',
+        payload: response.data.message,
+      });
+    } catch (error) {
+      errorHandler(error);
+    }
+  },
 };
 
 export default BackyardArticles;

--- a/src/modules/BackyardArticles.js
+++ b/src/modules/BackyardArticles.js
@@ -30,8 +30,7 @@ const BackyardArticles = {
   },
 
   async setStatus(id, status) {
-    let params = { status: status === 'Published' ? 'archived': 'published'};
-    debugger
+    let params = { status: status === 'Published' ? 'archived' : 'published' };
     try {
       let response = await axios.put(`/backyards/${id}`, params, {
         headers: getFromLocalStorage(),


### PR DESCRIPTION
**PT-Story:**  https://www.pivotaltracker.com/story/show/178339949
### User Story 
``` 
As an editor
In order to moderate the articles
I want to be able to have options to archive and publish articles
``` 
## Changes proposed in this pull request: 
* Makes action button dynamic for both types of articles
* Action button comes with publish/edit/preview/archive functionality
* Adds dynamic  preview modal for both types

## What I have learned working on this feature: 
* How to show status into table column
* Further experimenting with dynamic components

## Screenshots (Editor) 
![image](https://user-images.githubusercontent.com/75306727/120115503-3c831700-c184-11eb-8a5d-566c1e203bad.png)

![image](https://user-images.githubusercontent.com/75306727/120115519-4d338d00-c184-11eb-81c0-ef2e8c02b690.png)

![image](https://user-images.githubusercontent.com/75306727/120115552-7b18d180-c184-11eb-89de-01c50d7caa76.png)
